### PR TITLE
Fix case error in SQLiteTester main.swift

### DIFF
--- a/Sources/SQLiteTester/main.swift
+++ b/Sources/SQLiteTester/main.swift
@@ -1,4 +1,4 @@
-import Csqlite
+import CSQLite
 
 print("Hello, world!")
 let version = String(cString: sqlite3_libversion())


### PR DESCRIPTION
`SQLiteTester` doesn't currently build:

```
SQLiteTester/Sources/SQLiteTester/main.swift:1:8: error: no such module 'Csqlite'
import Csqlite
       ^
```

This is because the package is named `CSQLite`, not `Csqlite`.
